### PR TITLE
If the config file isn't valid, throw an error and exit (FIXES: #18)

### DIFF
--- a/src/fullerite/config/config.go
+++ b/src/fullerite/config/config.go
@@ -29,7 +29,11 @@ func ReadConfig(configFile string) (c Config, e error) {
 		log.Error("Config file error: ", e)
 		return c, e
 	}
-	json.Unmarshal(contents, &c)
+	err := json.Unmarshal(contents, &c)
+	if err != nil {
+    		log.Error("Invalid JSON in config: ", err)
+		return c, err
+	}
 	return c, nil
 }
 


### PR DESCRIPTION
If the JSON in the config file isn't valid for whatever reason, we should exit the process immediately.

According to #13 there aren't a lot of tests yet, so I'm submitting this without any tests.

Manual test:

```
# Ensure we have bad json
root@host fullerite]# cat /etc/fullerite.conf | python -m json.tool
Expecting , delimiter: line 19 column 13 (char 492)

[root@host fullerite]# fullerite -c /etc/fullerite.conf
INFO[19 Aug 15 00:05 BST] Starting fullerite...                         app=fullerite
INFO[19 Aug 15 00:05 BST] Reading configuration file at /etc/fullerite.conf  app=fullerite pkg=config
ERRO[19 Aug 15 00:05 BST] Invalid JSON in config: invalid character '"' after object key:value pair  app=fullerite pkg=config
```

This is the first time I've ever written any Go, so apologies if it's nasty/horrible!