### PR TITLE
fix lint warnings and reorg a little bit

### DIFF
--- a/src/fullerite/collector/nerve_uwsgi_test.go
+++ b/src/fullerite/collector/nerve_uwsgi_test.go
@@ -308,7 +308,6 @@ func TestUWSGIMetricConversion(t *testing.T) {
 func TestUWSGIResponseConversion(t *testing.T) {
 	uwsgiRsp := []byte(getTestUWSGIResponse())
 
-	inst := getTestNerveUWSGI()
 	actual, err := parseUWSGIMetrics(&uwsgiRsp)
 	assert.Nil(t, err)
 	validateUWSGIResults(t, actual)
@@ -382,11 +381,11 @@ func TestNonConflictingServiceQueries(t *testing.T) {
 	minimalNerveConfig := make(map[string]map[string]map[string]interface{})
 	minimalNerveConfig["services"] = map[string]map[string]interface{}{
 		"test_service.things.and.stuff": {
-			"host": goodIp,
+			"host": goodIP,
 			"port": goodPort,
 		},
 		"other_service.does.lots.of.stuff": {
-			"host": badIp,
+			"host": badIP,
 			"port": badPort,
 		},
 	}

--- a/src/fullerite/collector/nerve_uwsgi_test.go
+++ b/src/fullerite/collector/nerve_uwsgi_test.go
@@ -91,7 +91,7 @@ func getTestUWSGIResponse() string {
 	"timers": {
 		"some_timer": {
 			"average": 123
-		}, 
+		},
 		"othertimer": {
 			"mean": 345
 		}
@@ -170,7 +170,7 @@ func validateEmptyChannel(t *testing.T, c chan metric.Metric) {
 	}
 }
 
-func parseUrl(url string) (string, string) {
+func parseURL(url string) (string, string) {
 	parts := strings.Split(url, ":")
 	ip := strings.Replace(parts[1], "/", "", -1)
 	port := parts[2]
@@ -309,7 +309,7 @@ func TestUWSGIResponseConversion(t *testing.T) {
 	uwsgiRsp := []byte(getTestUWSGIResponse())
 
 	inst := getTestNerveUWSGI()
-	actual, err := inst.parseUWSGIMetrics(&uwsgiRsp)
+	actual, err := parseUWSGIMetrics(&uwsgiRsp)
 	assert.Nil(t, err)
 	validateUWSGIResults(t, actual)
 	for _, m := range actual {
@@ -325,7 +325,7 @@ func TestNerveUWSGICollect(t *testing.T) {
 	defer server.Close()
 
 	// assume format is http://ipaddr:port
-	ip, port := parseUrl(server.URL)
+	ip, port := parseURL(server.URL)
 
 	minimalNerveConfig := make(map[string]map[string]map[string]interface{})
 	minimalNerveConfig["services"] = map[string]map[string]interface{}{
@@ -376,8 +376,8 @@ func TestNonConflictingServiceQueries(t *testing.T) {
 	}))
 	defer badServer.Close()
 
-	goodIp, goodPort := parseUrl(goodServer.URL)
-	badIp, badPort := parseUrl(badServer.URL)
+	goodIP, goodPort := parseURL(goodServer.URL)
+	badIP, badPort := parseURL(badServer.URL)
 
 	minimalNerveConfig := make(map[string]map[string]map[string]interface{})
 	minimalNerveConfig["services"] = map[string]map[string]interface{}{

--- a/src/fullerite/metric/metric.go
+++ b/src/fullerite/metric/metric.go
@@ -60,16 +60,17 @@ func (m *Metric) GetDimensionValue(dimension string) (value string, ok bool) {
 	return
 }
 
-func sanitizeString(s string) string {
-	s = strings.Replace(s, "=", "-", -1)
-	s = strings.Replace(s, ":", "-", -1)
-	return s
-}
-
+// AddToAll adds a map of dimensions to a list of metrics
 func AddToAll(metrics *[]Metric, dims map[string]string) {
 	for _, m := range *metrics {
 		for key, value := range dims {
 			m.AddDimension(key, value)
 		}
 	}
+}
+
+func sanitizeString(s string) string {
+	s = strings.Replace(s, "=", "-", -1)
+	s = strings.Replace(s, ":", "-", -1)
+	return s
 }


### PR DESCRIPTION
* fix lint warnings on naming
* add doc to exported metric.AddToAll function
* Consistent pointer methods in nerveUWSGICollector (see http://nathanleclaire.com/blog/2014/08/09/dont-get-bitten-by-pointer-vs-non-pointer-method-receivers-in-golang/)
* parseUWSGIMetrics doesn't need to be a method