### PR TITLE
faster collector tests

### DIFF
--- a/src/fullerite/collector/nerve_uwsgi_test.go
+++ b/src/fullerite/collector/nerve_uwsgi_test.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	l "github.com/Sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -371,7 +370,7 @@ func TestNonConflictingServiceQueries(t *testing.T) {
 	defer goodServer.Close()
 
 	badServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, rsp *http.Request) {
-		time.Sleep(time.Duration(5) * time.Second) // much longer than the actual timeout
+		return // no response
 	}))
 	defer badServer.Close()
 


### PR DESCRIPTION
Looks like sleep in uwsgi test doesn't cause a timeout anyway. Not returning metrics has the same behavior. 

```
-->  (master) make test
[.. snip ..]
ok  	fullerite/collector	5.124s	coverage: 90.9% of statements
[.. snip ..]
```

vs 

```
-->  (faster_collecter_tests) make test
[.. snip ..]
ok  	fullerite/collector	0.124s	coverage: 90.9% of statements
[.. snip ..]
```