### PR TITLE
Fixed a bug that prevented the handlerLevelDimensions from being read

### DIFF
--- a/src/fullerite/config/config.go
+++ b/src/fullerite/config/config.go
@@ -86,7 +86,7 @@ func GetAsInt(value interface{}, defaultValue int) (result int) {
 
 // GetAsMap parses a string to a map[string]string
 func GetAsMap(value interface{}) (result map[string]string) {
-	result = map[string]string{}
+	result = make(map[string]string)
 
 	switch value.(type) {
 	case string:
@@ -94,9 +94,17 @@ func GetAsMap(value interface{}) (result map[string]string) {
 		if err != nil {
 			log.Warn("Failed to convert value", value, "to a map")
 		}
+	case map[string]interface{}:
+		temp := value.(map[string]interface{})
+		for k, v := range temp {
+			if str, ok := v.(string); ok {
+				result[k] = str
+			} else {
+				log.Warn("Expected a string but got", reflect.TypeOf(value), ". Discarding handler level metric: ", k)
+			}
+		}
 	default:
 		log.Warn("Expected a string but got", reflect.TypeOf(value), ". Returning empty map!")
-		result = make(map[string]string)
 	}
 
 	return

--- a/src/fullerite/config/config_test.go
+++ b/src/fullerite/config/config_test.go
@@ -113,14 +113,14 @@ func TestGetFloat(t *testing.T) {
 func TestGetAsMap(t *testing.T) {
 	assert := assert.New(t)
 
-	string_to_parse := "{\"runtimeenv\" : \"dev\", \"region\":\"uswest1-devc\"}"
-	expected_value := map[string]string{
+	stringToParse := "{\"runtimeenv\" : \"dev\", \"region\":\"uswest1-devc\"}"
+	expectedValue := map[string]string{
 		"runtimeenv": "dev",
 		"region":     "uswest1-devc",
 	}
 
-	val := config.GetAsMap(string_to_parse)
-	assert.Equal(val, expected_value)
+	val := config.GetAsMap(stringToParse)
+	assert.Equal(val, expectedValue)
 }
 
 func TestParseGoodConfig(t *testing.T) {

--- a/src/fullerite/config/config_test.go
+++ b/src/fullerite/config/config_test.go
@@ -113,14 +113,19 @@ func TestGetFloat(t *testing.T) {
 func TestGetAsMap(t *testing.T) {
 	assert := assert.New(t)
 
+	// Test if string can be converted to map[string]string
 	stringToParse := "{\"runtimeenv\" : \"dev\", \"region\":\"uswest1-devc\"}"
 	expectedValue := map[string]string{
 		"runtimeenv": "dev",
 		"region":     "uswest1-devc",
 	}
+	assert.Equal(config.GetAsMap(stringToParse), expectedValue)
 
-	val := config.GetAsMap(stringToParse)
-	assert.Equal(val, expectedValue)
+	// Test if map[string]interface{} can be converted to map[string]string
+	interfaceMapToParse := make(map[string]interface{})
+	interfaceMapToParse["runtimeenv"] = "dev"
+	interfaceMapToParse["region"] = "uswest1-devc"
+	assert.Equal(config.GetAsMap(stringToParse), expectedValue)
 }
 
 func TestParseGoodConfig(t *testing.T) {

--- a/src/fullerite/config/config_test.go
+++ b/src/fullerite/config/config_test.go
@@ -125,7 +125,7 @@ func TestGetAsMap(t *testing.T) {
 	interfaceMapToParse := make(map[string]interface{})
 	interfaceMapToParse["runtimeenv"] = "dev"
 	interfaceMapToParse["region"] = "uswest1-devc"
-	assert.Equal(config.GetAsMap(stringToParse), expectedValue)
+	assert.Equal(config.GetAsMap(interfaceMapToParse), expectedValue)
 }
 
 func TestParseGoodConfig(t *testing.T) {

--- a/src/fullerite/handler/handler.go
+++ b/src/fullerite/handler/handler.go
@@ -215,8 +215,8 @@ func (base *BaseHandler) configureCommonParams(configMap map[string]interface{})
 
 	// Default dimensions can be extended or overridden on a per handler basis.
 	if asInterface, exists := configMap["defaultDimensions"]; exists == true {
-		handler_level_dimensions := config.GetAsMap(asInterface)
-		base.SetDefaultDimensions(handler_level_dimensions)
+		handlerLevelDimensions := config.GetAsMap(asInterface)
+		base.SetDefaultDimensions(handlerLevelDimensions)
 	}
 }
 

--- a/src/fullerite/handler/handler_test.go
+++ b/src/fullerite/handler/handler_test.go
@@ -51,9 +51,9 @@ func TestPerHandlerDimensions(t *testing.T) {
 	b.SetDefaultDimensions(dims)
 	assert.Equal(t, 2, len(b.DefaultDimensions()))
 
-	handler_level_dimensions := "{ \"test\" : \"updated value\", \"runtimeenv\": \"dev\", \"region\":\"uswest1-devc\"}"
+	handlerLevelDimensions := "{ \"test\" : \"updated value\", \"runtimeenv\": \"dev\", \"region\":\"uswest1-devc\"}"
 	configMap := map[string]interface{}{
-		"defaultDimensions": handler_level_dimensions,
+		"defaultDimensions": handlerLevelDimensions,
 	}
 
 	b.configureCommonParams(configMap)


### PR DESCRIPTION
handler level dimensions present in the config are of type map[string]interface{}. Added an extra case in GetAsMap to handle this!

Tested this on my dev box to make sure this works